### PR TITLE
feat: add SW64 architecture support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+hwinfo (23.2-0deepin6) unstable; urgency=medium
+
+  * add sw64 support
+
+ -- Liu zheng <liuzheng@uniontech.com>  Wed, 02 Apr 2025 21:40:16 +0800
+
 hwinfo (23.2-0deepin5) unstable; urgency=medium
 
   * fix memory leaks in hardware detection.

--- a/debian/patches/add-sw64-architecture-support.patch
+++ b/debian/patches/add-sw64-architecture-support.patch
@@ -1,0 +1,15 @@
+Index: hwinfo/src/hd/hd.c
+===================================================================
+--- hwinfo.orig/src/hd/hd.c
++++ hwinfo/src/hd/hd.c
+@@ -174,6 +174,10 @@
+ #define HD_ARCH "sh"
+ #endif
+ 
++#ifdef __sw_64__
++#define HD_ARCH "sw_64"
++#endif
++
+ typedef struct disk_s {
+   struct disk_s *next;
+   unsigned crc;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,4 @@
 uniontech018_fix_serial_code.patch
 0010-update-pci-usb-ids.patch
 0011-fix-memory-leaks-in-hardware-detection.patch
+add-sw64-architecture-support.patch


### PR DESCRIPTION
- Added SW64 architecture detection in hd.c by defining HD_ARCH as "sw_64" when __sw_64__ is defined
- Created new patch file: add-sw64-architecture-support.patch
- Added the new patch to the series file
- Updated debian/changelog with version bump to 23.2-0deepin6

This change enables hwinfo to properly identify SW64 architecture systems.